### PR TITLE
Gracefully exit when not motifs are found

### DIFF
--- a/src/EXTREME.py
+++ b/src/EXTREME.py
@@ -436,6 +436,7 @@ def extreme(Y,neg_seqs,minsites,maxsites,pwm_guess,initialstep=0.05,tries=15,rev
     #if no valid motif found, then exit
     if len(logevs) == 0:
         print 'No motif found, so do nothing...'
+        sys.exit()
     best_index = argmin(logevs)
     best_theta_motif = theta_motifs[best_index]
     best_theta_background_matrix = theta_background_matrices[best_index]


### PR DESCRIPTION
Currently, EXTREME.py execution fails when `len(logevs) == 0` and prints an uninformative error message.

It may be better to print a message that no motifs are found and then explicitly stop execution with `sys.exit()`.
